### PR TITLE
Add exponential backoff retry policy for long polling

### DIFF
--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/poller/DefaultUpdatePoller.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/poller/DefaultUpdatePoller.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
@@ -76,6 +77,7 @@ public class DefaultUpdatePoller implements UpdatePoller, Closeable {
     }
 
     private void runLoop() {
+        int failureCount = 0;
         try {
             if (properties.getDropPendingOnStart()) {
                 drainPendingUpdates();
@@ -93,11 +95,12 @@ public class DefaultUpdatePoller implements UpdatePoller, Closeable {
                     log.warn("Error while executing GetUpdates request", ex);
 
                     try {
-                        Thread.sleep(properties.getRetryDelay().toMillis());
+                        Thread.sleep(computeRetryDelay(failureCount));
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
                         break;
                     }
+                    failureCount++;
                     continue;
                 }
 
@@ -111,6 +114,7 @@ public class DefaultUpdatePoller implements UpdatePoller, Closeable {
                     continue;
                 }
 
+                failureCount = 0;
                 List<Update> updates = getUpdatesResponse.updates();
                 updateDelivery.deliver(updates);
 
@@ -152,6 +156,18 @@ public class DefaultUpdatePoller implements UpdatePoller, Closeable {
         getUpdates.limit(properties.getLimit());
 
         return getUpdates;
+    }
+
+    private long computeRetryDelay(int failureCount) {
+        if (!properties.getBackoffEnabled()) {
+            return properties.getRetryDelay().toMillis();
+        }
+        long baseDelay = properties.getRetryDelay().toMillis();
+        long maxDelay = properties.getBackoffMaxDelay().toMillis();
+        double multiplier = properties.getBackoffMultiplier();
+        long exponential = (long) (baseDelay * Math.pow(multiplier, failureCount));
+        long jitter = ThreadLocalRandom.current().nextLong(0, Math.max(1, baseDelay));
+        return Math.min(exponential + jitter, maxDelay);
     }
 
     private ExecutorService buildExecutorService() {

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/properties/LongPollingProperties.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/properties/LongPollingProperties.java
@@ -19,6 +19,9 @@ public class LongPollingProperties {
     private static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(2);
     private static final boolean DEFAULT_DROP_PENDING_ON_START = false;
     private static final int DEFAULT_LIMIT = 100;
+    private static final boolean DEFAULT_BACKOFF_ENABLED = true;
+    private static final Duration DEFAULT_BACKOFF_MAX_DELAY = Duration.ofSeconds(60);
+    private static final double DEFAULT_BACKOFF_MULTIPLIER = 2.0;
 
     /**
      * Delay before retrying a failed poll request.
@@ -56,6 +59,21 @@ public class LongPollingProperties {
      * Maximum time to wait for poller shutdown during application stop.
      */
     private Duration shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
+
+    /**
+     * Whether to use exponential backoff with jitter when retrying failed poll requests.
+     */
+    private boolean backoffEnabled = DEFAULT_BACKOFF_ENABLED;
+
+    /**
+     * Maximum delay cap for exponential backoff retries.
+     */
+    private Duration backoffMaxDelay = DEFAULT_BACKOFF_MAX_DELAY;
+
+    /**
+     * Multiplier applied to the retry delay on each consecutive failure.
+     */
+    private double backoffMultiplier = DEFAULT_BACKOFF_MULTIPLIER;
 
 
     public Duration getShutdownTimeout() {
@@ -104,5 +122,29 @@ public class LongPollingProperties {
 
     public void setDropPendingOnStart(boolean dropPendingOnStart) {
         this.dropPendingOnStart = dropPendingOnStart;
+    }
+
+    public boolean getBackoffEnabled() {
+        return backoffEnabled;
+    }
+
+    public void setBackoffEnabled(boolean backoffEnabled) {
+        this.backoffEnabled = backoffEnabled;
+    }
+
+    public Duration getBackoffMaxDelay() {
+        return backoffMaxDelay;
+    }
+
+    public void setBackoffMaxDelay(Duration backoffMaxDelay) {
+        this.backoffMaxDelay = backoffMaxDelay;
+    }
+
+    public double getBackoffMultiplier() {
+        return backoffMultiplier;
+    }
+
+    public void setBackoffMultiplier(double backoffMultiplier) {
+        this.backoffMultiplier = backoffMultiplier;
     }
 }

--- a/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/poller/DefaultUpdatePollerTest.java
+++ b/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/poller/DefaultUpdatePollerTest.java
@@ -39,6 +39,7 @@ class DefaultUpdatePollerTest {
         when(properties.getLimit()).thenReturn(100);
         when(properties.getRetryDelay()).thenReturn(Duration.ZERO);
         when(properties.getShutdownTimeout()).thenReturn(Duration.ofSeconds(1));
+        when(properties.getBackoffEnabled()).thenReturn(false);
         when(offsetStore.read()).thenReturn(0);
     }
 
@@ -188,5 +189,111 @@ class DefaultUpdatePollerTest {
         poller.start(); // should not break anything
 
         poller.stop();
+    }
+
+    // --------------------------------------------------
+    // computeRetryDelay()
+    // --------------------------------------------------
+
+    @Test
+    void computeRetryDelayShouldGrowExponentiallyWithFailureCount() throws Exception {
+        when(properties.getBackoffEnabled()).thenReturn(true);
+        when(properties.getRetryDelay()).thenReturn(Duration.ofMillis(100));
+        when(properties.getBackoffMaxDelay()).thenReturn(Duration.ofMinutes(1));
+        when(properties.getBackoffMultiplier()).thenReturn(2.0);
+
+        DefaultUpdatePoller poller = createPoller();
+        Method method = DefaultUpdatePoller.class.getDeclaredMethod("computeRetryDelay", int.class);
+        method.setAccessible(true);
+
+        long delay0 = (long) method.invoke(poller, 0);
+        long delay1 = (long) method.invoke(poller, 1);
+        long delay2 = (long) method.invoke(poller, 2);
+
+        assertTrue(delay0 >= 100L, "First retry should be at least base delay");
+        assertTrue(delay1 >= 200L, "Second retry should be at least 2x base delay");
+        assertTrue(delay2 >= 400L, "Third retry should be at least 4x base delay");
+    }
+
+    @Test
+    void computeRetryDelayShouldBeCappedAtMaxDelay() throws Exception {
+        when(properties.getBackoffEnabled()).thenReturn(true);
+        when(properties.getRetryDelay()).thenReturn(Duration.ofMillis(100));
+        when(properties.getBackoffMaxDelay()).thenReturn(Duration.ofMillis(300));
+        when(properties.getBackoffMultiplier()).thenReturn(2.0);
+
+        DefaultUpdatePoller poller = createPoller();
+        Method method = DefaultUpdatePoller.class.getDeclaredMethod("computeRetryDelay", int.class);
+        method.setAccessible(true);
+
+        long delay = (long) method.invoke(poller, 10);
+
+        assertTrue(delay <= 300L, "Delay should be capped at backoffMaxDelay");
+    }
+
+    @Test
+    void computeRetryDelayShouldReturnFixedDelayWhenBackoffDisabled() throws Exception {
+        when(properties.getBackoffEnabled()).thenReturn(false);
+        when(properties.getRetryDelay()).thenReturn(Duration.ofMillis(500));
+
+        DefaultUpdatePoller poller = createPoller();
+        Method method = DefaultUpdatePoller.class.getDeclaredMethod("computeRetryDelay", int.class);
+        method.setAccessible(true);
+
+        long delay0 = (long) method.invoke(poller, 0);
+        long delay5 = (long) method.invoke(poller, 5);
+
+        assertEquals(500L, delay0);
+        assertEquals(500L, delay5);
+    }
+
+    @Test
+    void runLoopShouldRecoverAndResetBackoffAfterSuccessfulResponse() throws Exception {
+        when(properties.getDropPendingOnStart()).thenReturn(false);
+        when(properties.getBackoffEnabled()).thenReturn(true);
+        when(properties.getBackoffMaxDelay()).thenReturn(Duration.ofSeconds(60));
+        when(properties.getBackoffMultiplier()).thenReturn(2.0);
+
+        GetUpdatesResponse response = mock(GetUpdatesResponse.class);
+        Update update = mock(Update.class);
+        when(update.updateId()).thenReturn(42);
+        when(response.isOk()).thenReturn(true);
+        when(response.updates()).thenReturn(List.of(update));
+
+        CountDownLatch deliverLatch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            deliverLatch.countDown();
+            return null;
+        }).when(updateDelivery).deliver(anyList());
+
+        // First call throws, second call succeeds – verifies backoff reset path is reached
+        when(telegramBotExecutor.execute(any(GetUpdates.class)))
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(response);
+
+        DefaultUpdatePoller poller = createPoller();
+        setPrivateBooleanField(poller, "running", true);
+
+        Method runLoop = DefaultUpdatePoller.class.getDeclaredMethod("runLoop");
+        runLoop.setAccessible(true);
+
+        Thread t = new Thread(() -> {
+            try {
+                runLoop.invoke(poller);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, "test-backoff-reset-thread");
+
+        t.start();
+
+        assertTrue(deliverLatch.await(3, java.util.concurrent.TimeUnit.SECONDS),
+                "UpdateDelivery.deliver should be invoked after recovering from failure");
+
+        setPrivateBooleanField(poller, "running", false);
+        t.join(2000);
+
+        verify(updateDelivery, atLeastOnce()).deliver(anyList());
+        verify(offsetStore, atLeastOnce()).write(42);
     }
 }


### PR DESCRIPTION
Implement an exponential backoff retry strategy for the long polling update fetcher to gracefully handle transient failures and reduce server load during outages.

## Changes

The backoff policy includes:
- Configurable exponential backoff with a multiplier
- Maximum delay cap to prevent indefinitely long waits
- Random jitter to avoid thundering herd patterns
- Automatic failure counter reset on successful updates

## Configuration

New properties in `LongPollingProperties`:
- `backoff-enabled`: Enable/disable backoff behavior (default: false for backward compatibility)
- `backoff-multiplier`: Exponential multiplier for delay calculation (default: 2.0)
- `backoff-max-delay`: Maximum cap for retry delays

## Implementation Details

Failure count is tracked per polling cycle and incremented on each consecutive error. The retry delay is computed as:
```
min(baseDelay * multiplier^failureCount + jitter, maxDelay)
```

The failure counter resets immediately upon a successful update fetch, ensuring transient errors don't cause prolonged backoff.

Fixes #99