### PR TITLE
telegram bot apis failover implementation for long-polling mode

### DIFF
--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/TelegramBotClientFactory.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/TelegramBotClientFactory.java
@@ -1,0 +1,23 @@
+package io.ksilisk.telegrambot.core.executor;
+
+import io.ksilisk.telegrambot.core.file.TelegramBotFileClient;
+
+/**
+ * Factory for creating Telegram Bot API clients for the currently configured endpoint provider.
+ */
+public interface TelegramBotClientFactory {
+    /**
+     * Creates a Telegram Bot API request executor.
+     *
+     * @return executor instance
+     */
+    TelegramBotExecutor createExecutor();
+
+    /**
+     * Creates a Telegram Bot API file client.
+     *
+     * @param telegramBotExecutor executor used for Bot API metadata requests, such as file path resolution
+     * @return file client instance
+     */
+    TelegramBotFileClient createFileClient(TelegramBotExecutor telegramBotExecutor);
+}

--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/resolver/DefaultSwitchableTelegramBotApiUrlProvider.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/resolver/DefaultSwitchableTelegramBotApiUrlProvider.java
@@ -1,0 +1,85 @@
+package io.ksilisk.telegrambot.core.executor.resolver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DefaultSwitchableTelegramBotApiUrlProvider implements SwitchableTelegramBotApiUrlProvider {
+    private static final Logger log = LoggerFactory.getLogger(DefaultSwitchableTelegramBotApiUrlProvider.class);
+
+    private static final String DEFAULT_ENDPOINT = "https://api.telegram.org";
+
+    private final List<String> endpoints;
+    private final String botToken;
+    private final boolean testServer;
+
+    private final AtomicInteger currentIndex = new AtomicInteger();
+
+    public DefaultSwitchableTelegramBotApiUrlProvider(String botToken, boolean testServer, List<String> endpoints) {
+        this.botToken = botToken;
+        this.testServer = testServer;
+        this.endpoints = normalizeEndpoints(endpoints);
+    }
+
+    public DefaultSwitchableTelegramBotApiUrlProvider(String botToken, boolean testServer) {
+        this(botToken, testServer, List.of(DEFAULT_ENDPOINT));
+    }
+
+    @Override
+    public void switchToNext() {
+        if (endpoints.size() <= 1) {
+            log.debug("Telegram Bot API endpoint switch skipped: only one endpoint configured");
+            return;
+        }
+
+        int previousIndex = currentIndex.getAndUpdate(index -> (index + 1) % endpoints.size());
+        int current = currentIndex.get();
+
+        log.warn("Telegram Bot API endpoint switched: {} -> {}", endpoints.get(previousIndex), endpoints.get(current));
+    }
+
+    @Override
+    public String getApiUrl() {
+        return currentEndpoint() + "/bot" + botToken + suffix();
+    }
+
+    @Override
+    public String getFileUrl() {
+        return currentEndpoint() + "/file/bot" + botToken + suffix();
+    }
+
+    private String currentEndpoint() {
+        return endpoints.get(currentIndex.get());
+    }
+
+    private String suffix() {
+        return testServer ? "/test/" : "/";
+    }
+
+    private static List<String> normalizeEndpoints(List<String> endpoints) {
+        if (endpoints == null || endpoints.isEmpty()) {
+            return List.of(DEFAULT_ENDPOINT);
+
+        }
+
+        List<String> normalized = new ArrayList<>(endpoints.size());
+        for (String endpoint : endpoints) {
+            String value = normalizeEndpoint(endpoint);
+            if (!normalized.contains(value)) {
+                normalized.add(value);
+            }
+        }
+
+        return List.copyOf(normalized);
+    }
+
+    private static String normalizeEndpoint(String endpoint) {
+        while (endpoint.endsWith("/")) {
+            endpoint = endpoint.substring(0, endpoint.length() - 1);
+        }
+        return endpoint;
+    }
+}

--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/resolver/DefaultTelegramBotApiUrlProvider.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/resolver/DefaultTelegramBotApiUrlProvider.java
@@ -19,6 +19,6 @@ public class DefaultTelegramBotApiUrlProvider implements TelegramBotApiUrlProvid
 
     @Override
     public String getFileUrl() {
-        return FILE_URL + botToken +  (testServer ? "/test/" : "/");
+        return FILE_URL + botToken + (testServer ? "/test/" : "/");
     }
 }

--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/resolver/SwitchableTelegramBotApiUrlProvider.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/resolver/SwitchableTelegramBotApiUrlProvider.java
@@ -1,0 +1,11 @@
+package io.ksilisk.telegrambot.core.executor.resolver;
+
+/**
+ * {@link TelegramBotApiUrlProvider} that can switch the active Telegram Bot API endpoint at runtime.
+ */
+public interface SwitchableTelegramBotApiUrlProvider extends TelegramBotApiUrlProvider {
+     /**
+     * Switches the active endpoint to the next configured endpoint.
+     */
+    void switchToNext();
+}

--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/retry/RetryRule.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/retry/RetryRule.java
@@ -16,6 +16,7 @@ import io.ksilisk.telegrambot.core.order.CoreOrdered;
  * <p>This contract also extends {@link CoreOrdered}, so multiple rules
  * can be evaluated in a deterministic order.
  */
+@FunctionalInterface
 public interface RetryRule extends CoreOrdered {
     /**
      * Determines whether the given failed request should be retried.

--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/retry/RetryingTelegramBotClientFactory.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/executor/retry/RetryingTelegramBotClientFactory.java
@@ -1,0 +1,41 @@
+package io.ksilisk.telegrambot.core.executor.retry;
+
+import io.ksilisk.telegrambot.core.executor.TelegramBotClientFactory;
+import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.core.executor.retry.impl.CompositeRetryRule;
+import io.ksilisk.telegrambot.core.file.TelegramBotFileClient;
+
+public class RetryingTelegramBotClientFactory implements TelegramBotClientFactory {
+    private final TelegramBotClientFactory delegate;
+    private final boolean retryEnabled;
+    private final CompositeRetryRule retryRule;
+    private final RetryDelayStrategy retryDelayStrategy;
+
+    public RetryingTelegramBotClientFactory(TelegramBotClientFactory delegate,
+                                            boolean retryEnabled,
+                                            CompositeRetryRule retryRule,
+                                            RetryDelayStrategy retryDelayStrategy) {
+        this.delegate = delegate;
+        this.retryEnabled = retryEnabled;
+        this.retryRule = retryRule;
+        this.retryDelayStrategy = retryDelayStrategy;
+    }
+
+    @Override
+    public TelegramBotExecutor createExecutor() {
+        TelegramBotExecutor executor = delegate.createExecutor();
+        if (!retryEnabled) {
+            return executor;
+        }
+        if (retryRule == null || retryDelayStrategy == null) {
+            return executor;
+        }
+        return new RetryingTelegramBotExecutor(executor, retryRule, retryDelayStrategy);
+
+    }
+
+    @Override
+    public TelegramBotFileClient createFileClient(TelegramBotExecutor telegramBotExecutor) {
+        return delegate.createFileClient(telegramBotExecutor);
+    }
+}

--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/properties/ClientApiProperties.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/properties/ClientApiProperties.java
@@ -1,0 +1,28 @@
+package io.ksilisk.telegrambot.core.properties;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Telegram Bot API client endpoint settings.
+ */
+public class ClientApiProperties {
+    /**
+     * Base Telegram Bot API endpoints.
+     *
+     * <p>Values should not include {@code /bot} or the bot token. Example:
+     * {@code https://api.telegram.org}.</p>
+     */
+    @NotNull
+    private List<String> endpoints = new ArrayList<>();
+
+    public List<String> getEndpoints() {
+        return endpoints;
+    }
+
+    public void setEndpoints(List<String> endpoints) {
+        this.endpoints = endpoints;
+    }
+}

--- a/telegram-bot-core/src/test/java/io/ksilisk/telegrambot/core/executor/resolver/DefaultSwitchableTelegramBotApiUrlProviderTest.java
+++ b/telegram-bot-core/src/test/java/io/ksilisk/telegrambot/core/executor/resolver/DefaultSwitchableTelegramBotApiUrlProviderTest.java
@@ -1,0 +1,159 @@
+package io.ksilisk.telegrambot.core.executor.resolver;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultSwitchableTelegramBotApiUrlProviderTest {
+    @Test
+    void shouldUseDefaultEndpointWhenEndpointsAreNull() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider("token", false, null);
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://api.telegram.org/bottoken/");
+        assertThat(provider.getFileUrl())
+                .isEqualTo("https://api.telegram.org/file/bottoken/");
+    }
+
+    @Test
+    void shouldUseDefaultEndpointWhenEndpointsAreEmpty() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider("token", false, List.of());
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://api.telegram.org/bottoken/");
+        assertThat(provider.getFileUrl())
+                .isEqualTo("https://api.telegram.org/file/bottoken/");
+    }
+
+    @Test
+    void shouldBuildApiUrlFromConfiguredEndpoint() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider(
+                        "token",
+                        false,
+                        List.of("https://tg-api-1.internal")
+                );
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/");
+    }
+
+    @Test
+    void shouldBuildFileUrlFromConfiguredEndpoint() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider(
+                        "token",
+                        false,
+                        List.of("https://tg-api-1.internal")
+                );
+        assertThat(provider.getFileUrl())
+                .isEqualTo("https://tg-api-1.internal/file/bottoken/");
+    }
+
+    @Test
+    void shouldAppendTestSuffixWhenTestServerIsEnabled() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider(
+                        "token",
+                        true,
+                        List.of("https://tg-api-1.internal")
+                );
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/test/");
+        assertThat(provider.getFileUrl())
+                .isEqualTo("https://tg-api-1.internal/file/bottoken/test/");
+    }
+
+    @Test
+    void shouldNormalizeTrailingSlashes() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider(
+                        "token",
+                        false,
+                        List.of("https://tg-api-1.internal///")
+                );
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/");
+        assertThat(provider.getFileUrl())
+                .isEqualTo("https://tg-api-1.internal/file/bottoken/");
+    }
+
+    @Test
+    void shouldSwitchToNextEndpointSequentially() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider(
+                        "token",
+                        false,
+                        List.of(
+                                "https://tg-api-1.internal",
+                                "https://tg-api-2.internal",
+                                "https://tg-api-3.internal"
+                        )
+                );
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/");
+        provider.switchToNext();
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-2.internal/bottoken/");
+        provider.switchToNext();
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-3.internal/bottoken/");
+    }
+
+    @Test
+    void shouldSwitchCyclically() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider(
+                        "token",
+                        false,
+                        List.of(
+                                "https://tg-api-1.internal",
+                                "https://tg-api-2.internal"
+                        )
+                );
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/");
+        provider.switchToNext();
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-2.internal/bottoken/");
+        provider.switchToNext();
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/");
+    }
+
+    @Test
+    void shouldNotSwitchWhenOnlyOneEndpointConfigured() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider(
+                        "token",
+                        false,
+                        List.of("https://tg-api-1.internal")
+                );
+        provider.switchToNext();
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/");
+    }
+
+    @Test
+    void shouldDeduplicateNormalizedEndpoints() {
+        DefaultSwitchableTelegramBotApiUrlProvider provider =
+                new DefaultSwitchableTelegramBotApiUrlProvider(
+                        "token",
+                        false,
+                        List.of(
+                                "https://tg-api-1.internal",
+                                "https://tg-api-1.internal/",
+                                "https://tg-api-2.internal"
+                        )
+                );
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/");
+        provider.switchToNext();
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-2.internal/bottoken/");
+        provider.switchToNext();
+        assertThat(provider.getApiUrl())
+                .isEqualTo("https://tg-api-1.internal/bottoken/");
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/TelegramBotLongPollingAutoConfiguration.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/TelegramBotLongPollingAutoConfiguration.java
@@ -1,54 +1,16 @@
 package io.ksilisk.telegrambot.longpolling;
 
-import io.ksilisk.telegrambot.core.delivery.UpdateDelivery;
-import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
-import io.ksilisk.telegrambot.core.poller.UpdatePoller;
-import io.ksilisk.telegrambot.longpolling.ingress.DefaultLongPollingUpdateIngress;
-import io.ksilisk.telegrambot.longpolling.ingress.LongPollingUpdateIngress;
-import io.ksilisk.telegrambot.longpolling.poller.DefaultUpdatePoller;
-import io.ksilisk.telegrambot.longpolling.properties.LongPollingProperties;
-import io.ksilisk.telegrambot.longpolling.retry.GetUpdatesExcludedRetryRule;
-import io.ksilisk.telegrambot.longpolling.store.InMemoryOffsetStore;
-import io.ksilisk.telegrambot.longpolling.store.OffsetStore;
+import io.ksilisk.telegrambot.longpolling.configuration.LongPollingIngressConfiguration;
+import io.ksilisk.telegrambot.longpolling.configuration.LongPollingMasterConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 
 @AutoConfiguration
 @ConditionalOnProperty(prefix = "telegram.bot", name = "mode", havingValue = "LONG_POLLING", matchIfMissing = true)
+@Import({
+        LongPollingMasterConfiguration.class,
+        LongPollingIngressConfiguration.class,
+})
 public class TelegramBotLongPollingAutoConfiguration {
-    @Bean
-    @ConfigurationProperties(prefix = "telegram.bot.long-polling")
-    public LongPollingProperties longPollingProperties() {
-        return new LongPollingProperties();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(UpdatePoller.class)
-    public UpdatePoller updatePoller(OffsetStore offsetStore,
-                                     TelegramBotExecutor telegramBotExecutor,
-                                     LongPollingProperties longPollingProperties,
-                                     UpdateDelivery updateDelivery) {
-        return new DefaultUpdatePoller(offsetStore, telegramBotExecutor,
-                updateDelivery, longPollingProperties);
-    }
-
-    @Bean(initMethod = "start", destroyMethod = "stop")
-    @ConditionalOnMissingBean(LongPollingUpdateIngress.class)
-    public LongPollingUpdateIngress longPollingUpdateIngress(UpdatePoller updatePoller) {
-        return new DefaultLongPollingUpdateIngress(updatePoller);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(OffsetStore.class)
-    public OffsetStore offsetStore() {
-        return new InMemoryOffsetStore();
-    }
-
-    @Bean
-    public GetUpdatesExcludedRetryRule getUpdatesExcludedRetryRule() {
-        return new GetUpdatesExcludedRetryRule();
-    }
 }

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/configuration/LongPollingIngressConfiguration.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/configuration/LongPollingIngressConfiguration.java
@@ -1,0 +1,61 @@
+package io.ksilisk.telegrambot.longpolling.configuration;
+
+import io.ksilisk.telegrambot.core.delivery.UpdateDelivery;
+import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.core.poller.UpdatePoller;
+import io.ksilisk.telegrambot.longpolling.executor.ReportingMasterAwareTelegramBotExecutor;
+import io.ksilisk.telegrambot.longpolling.failover.MasterManager;
+import io.ksilisk.telegrambot.longpolling.ingress.DefaultLongPollingUpdateIngress;
+import io.ksilisk.telegrambot.longpolling.ingress.LongPollingUpdateIngress;
+import io.ksilisk.telegrambot.longpolling.poller.DefaultUpdatePoller;
+import io.ksilisk.telegrambot.longpolling.properties.LongPollingProperties;
+import io.ksilisk.telegrambot.longpolling.retry.GetUpdatesExcludedRetryRule;
+import io.ksilisk.telegrambot.longpolling.store.InMemoryOffsetStore;
+import io.ksilisk.telegrambot.longpolling.store.OffsetStore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class LongPollingIngressConfiguration {
+    @Bean
+    @ConfigurationProperties(prefix = "telegram.bot.long-polling")
+    public LongPollingProperties longPollingProperties() {
+        return new LongPollingProperties();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(UpdatePoller.class)
+    public UpdatePoller updatePoller(OffsetStore offsetStore,
+                                     TelegramBotExecutor telegramBotExecutor,
+                                     LongPollingProperties longPollingProperties,
+                                     UpdateDelivery updateDelivery,
+                                     MasterManager masterManager) {
+        TelegramBotExecutor executor = telegramBotExecutor;
+
+        if (longPollingProperties.getFailover().getEnabled()) {
+            executor = new ReportingMasterAwareTelegramBotExecutor(executor, masterManager);
+        }
+
+        return new DefaultUpdatePoller(offsetStore, executor,
+                updateDelivery, longPollingProperties);
+    }
+
+    @Bean(initMethod = "start", destroyMethod = "stop")
+    @ConditionalOnMissingBean(LongPollingUpdateIngress.class)
+    public LongPollingUpdateIngress longPollingUpdateIngress(UpdatePoller updatePoller) {
+        return new DefaultLongPollingUpdateIngress(updatePoller);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(OffsetStore.class)
+    public OffsetStore offsetStore() {
+        return new InMemoryOffsetStore();
+    }
+
+    @Bean
+    public GetUpdatesExcludedRetryRule getUpdatesExcludedRetryRule() {
+        return new GetUpdatesExcludedRetryRule();
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/configuration/LongPollingMasterConfiguration.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/configuration/LongPollingMasterConfiguration.java
@@ -1,0 +1,41 @@
+package io.ksilisk.telegrambot.longpolling.configuration;
+
+import io.ksilisk.telegrambot.core.executor.resolver.SwitchableTelegramBotApiUrlProvider;
+import io.ksilisk.telegrambot.longpolling.failover.MasterFailureClassifier;
+import io.ksilisk.telegrambot.longpolling.failover.MasterManager;
+import io.ksilisk.telegrambot.longpolling.failover.MasterSwitchPolicy;
+import io.ksilisk.telegrambot.longpolling.failover.impl.DefaultMasterFailureClassifier;
+import io.ksilisk.telegrambot.longpolling.failover.impl.DefaultMasterManager;
+import io.ksilisk.telegrambot.longpolling.failover.policy.duration.DurationBasedMasterSwitchPolicy;
+import io.ksilisk.telegrambot.longpolling.properties.LongPollingProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class LongPollingMasterConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    MasterFailureClassifier longPollingMasterFailureClassifier() {
+        return new DefaultMasterFailureClassifier();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    MasterSwitchPolicy longPollingMasterSwitchPolicy(LongPollingProperties properties,
+                                                     MasterFailureClassifier failureClassifier) {
+        return switch (properties.getFailover().getPolicy()) {
+            case DURATION -> new DurationBasedMasterSwitchPolicy(
+                    failureClassifier,
+                    properties.getFailover().getDuration().getSwitchAfter()
+            );
+        };
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    MasterManager longPollingMasterManager(MasterSwitchPolicy switchPolicy,
+                                           SwitchableTelegramBotApiUrlProvider apiUrlProvider) {
+        return new DefaultMasterManager(switchPolicy, apiUrlProvider);
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/executor/ReportingMasterAwareTelegramBotExecutor.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/executor/ReportingMasterAwareTelegramBotExecutor.java
@@ -1,0 +1,41 @@
+package io.ksilisk.telegrambot.longpolling.executor;
+
+import com.pengrad.telegrambot.request.BaseRequest;
+import com.pengrad.telegrambot.response.BaseResponse;
+import io.ksilisk.telegrambot.core.exception.request.TelegramRequestException;
+import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.longpolling.failover.MasterManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link TelegramBotExecutor} decorator that reports request results to a {@link MasterManager}.
+ *
+ * <p>Intended for long polling requests only. Successful executions reset the master switch policy,
+ * while failures are reported as possible switch candidates.</p>
+ */
+public final class ReportingMasterAwareTelegramBotExecutor implements TelegramBotExecutor {
+    private static final Logger log = LoggerFactory.getLogger(ReportingMasterAwareTelegramBotExecutor.class);
+
+    private final TelegramBotExecutor delegate;
+    private final MasterManager masterManager;
+
+    public ReportingMasterAwareTelegramBotExecutor(TelegramBotExecutor delegate, MasterManager masterManager) {
+        this.delegate = delegate;
+        this.masterManager = masterManager;
+    }
+
+    @Override
+    public <T extends BaseRequest<T, R>, R extends BaseResponse> R execute(BaseRequest<T, R> request)
+            throws TelegramRequestException {
+        try {
+            R response = delegate.execute(request);
+            masterManager.recordSuccess();
+            return response;
+        } catch (RuntimeException ex) {
+            log.debug("Long polling request failed, reporting failure to master manager", ex);
+            masterManager.recordFailure(ex);
+            throw ex;
+        }
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/MasterFailureClassifier.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/MasterFailureClassifier.java
@@ -1,0 +1,14 @@
+package io.ksilisk.telegrambot.longpolling.failover;
+
+/**
+ * Classifies failures that should contribute to master endpoint switching.
+ */
+public interface MasterFailureClassifier {
+    /**
+     * Returns whether the given failure should be treated as a master endpoint failure.
+     *
+     * @param throwable failure to classify
+     * @return {@code true} if the failure should affect failover state
+     */
+    boolean isFailure(Throwable throwable);
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/MasterManager.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/MasterManager.java
@@ -1,0 +1,22 @@
+package io.ksilisk.telegrambot.longpolling.failover;
+
+/**
+ * Facade for reporting master endpoint health.
+ *
+ * <p>The manager hides switch policy and endpoint selection details from callers.</p>
+ */
+public interface MasterManager {
+    /**
+     * Facade for reporting master endpoint health.
+     *
+     * <p>The manager hides switch policy and endpoint selection details from callers.</p>
+     */
+    void recordSuccess();
+
+    /**
+     * Records a failed operation against the current master endpoint.
+     *
+     * @param throwable failure to evaluate
+     */
+    void recordFailure(Throwable throwable);
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/MasterSwitchPolicy.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/MasterSwitchPolicy.java
@@ -1,0 +1,32 @@
+package io.ksilisk.telegrambot.longpolling.failover;
+
+/**
+ * Policy that decides when the current Telegram Bot API master endpoint should be switched.
+ *
+ * <p>Implementations may use different strategies, such as duration-based or count-based failure tracking.</p>
+ */
+public interface MasterSwitchPolicy {
+    /**
+     * Records a successful interaction with the current master endpoint.
+     */
+    void recordSuccess();
+
+    /**
+     * Records a failed interaction with the current master endpoint.
+     *
+     * @param throwable failure to evaluate
+     */
+    void recordFailure(Throwable throwable);
+
+    /**
+     * Returns whether the current master endpoint should be switched.
+     *
+     * @return {@code true} if a switch is required
+     */
+    boolean shouldSwitch();
+
+    /**
+     * Resets the policy state after recovery or after a master switch.
+     */
+    void reset();
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/impl/DefaultMasterFailureClassifier.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/impl/DefaultMasterFailureClassifier.java
@@ -1,0 +1,19 @@
+package io.ksilisk.telegrambot.longpolling.failover.impl;
+
+import io.ksilisk.telegrambot.longpolling.failover.MasterFailureClassifier;
+
+import java.io.IOException;
+
+public class DefaultMasterFailureClassifier implements MasterFailureClassifier {
+    @Override
+    public boolean isFailure(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof IOException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/impl/DefaultMasterManager.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/impl/DefaultMasterManager.java
@@ -1,0 +1,35 @@
+package io.ksilisk.telegrambot.longpolling.failover.impl;
+
+import io.ksilisk.telegrambot.core.executor.resolver.SwitchableTelegramBotApiUrlProvider;
+import io.ksilisk.telegrambot.longpolling.failover.MasterManager;
+import io.ksilisk.telegrambot.longpolling.failover.MasterSwitchPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultMasterManager implements MasterManager {
+    private static final Logger log = LoggerFactory.getLogger(DefaultMasterManager.class);
+
+    private final MasterSwitchPolicy switchPolicy;
+    private final SwitchableTelegramBotApiUrlProvider apiUrlProvider;
+
+    public DefaultMasterManager(MasterSwitchPolicy switchPolicy, SwitchableTelegramBotApiUrlProvider apiUrlProvider) {
+        this.switchPolicy = switchPolicy;
+        this.apiUrlProvider = apiUrlProvider;
+    }
+
+    @Override
+    public synchronized void recordSuccess() {
+        switchPolicy.recordSuccess();
+    }
+
+    @Override
+    public synchronized void recordFailure(Throwable throwable) {
+        switchPolicy.recordFailure(throwable);
+        if (!switchPolicy.shouldSwitch()) {
+            log.debug("Long polling failure recorded, master switch condition is not met yet: {}", throwable.toString());
+            return;
+        }
+        apiUrlProvider.switchToNext();
+        switchPolicy.reset();
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/policy/duration/DurationBasedMasterSwitchPolicy.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/policy/duration/DurationBasedMasterSwitchPolicy.java
@@ -48,7 +48,7 @@ public class DurationBasedMasterSwitchPolicy implements MasterSwitchPolicy {
 
     public void recordFailure(Throwable throwable) {
         if (!failureClassifier.isFailure(throwable)) {
-            log.debug("Long polling failure ignored by classifier: {}", throwable.toString());
+            log.debug("Long polling failure ignored by classifier: {}", String.valueOf(throwable));
             return;
         }
         Instant now = Instant.now(clock);

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/policy/duration/DurationBasedMasterSwitchPolicy.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/failover/policy/duration/DurationBasedMasterSwitchPolicy.java
@@ -1,0 +1,78 @@
+package io.ksilisk.telegrambot.longpolling.failover.policy.duration;
+
+import io.ksilisk.telegrambot.longpolling.failover.MasterFailureClassifier;
+import io.ksilisk.telegrambot.longpolling.failover.MasterSwitchPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * {@link MasterSwitchPolicy} that switches master after failures continue for a configured duration.
+ *
+ * <p>A successful operation resets the failure window.</p>
+ */
+public class DurationBasedMasterSwitchPolicy implements MasterSwitchPolicy {
+    private static final Logger log = LoggerFactory.getLogger(DurationBasedMasterSwitchPolicy.class);
+
+    private final MasterFailureClassifier failureClassifier;
+    private final Duration switchAfter;
+    private final Clock clock;
+
+    private Instant firstFailureAt;
+    private boolean switchRequired;
+
+    public DurationBasedMasterSwitchPolicy(MasterFailureClassifier failureClassifier, Duration switchAfter) {
+        this(failureClassifier, switchAfter, Clock.systemUTC());
+    }
+
+    DurationBasedMasterSwitchPolicy(MasterFailureClassifier failureClassifier, Duration switchAfter, Clock clock) {
+        this.failureClassifier = Objects.requireNonNull(failureClassifier);
+        this.switchAfter = Objects.requireNonNull(switchAfter);
+        this.clock = Objects.requireNonNull(clock);
+
+        if (switchAfter.isNegative()) {
+            throw new IllegalArgumentException("switchAfter must not be negative");
+        }
+    }
+
+    @Override
+    public void recordSuccess() {
+        reset();
+    }
+
+    @Override
+
+    public void recordFailure(Throwable throwable) {
+        if (!failureClassifier.isFailure(throwable)) {
+            log.debug("Long polling failure ignored by classifier: {}", throwable.toString());
+            return;
+        }
+        Instant now = Instant.now(clock);
+        if (firstFailureAt == null) {
+            firstFailureAt = now;
+            log.debug("Long polling failure window opened");
+        }
+        Duration failureDuration = Duration.between(firstFailureAt, now);
+
+        if (!failureDuration.minus(switchAfter).isNegative()) {
+            switchRequired = true;
+            log.debug("Long polling switch required: failureDuration={}, switchAfter={}", failureDuration, switchAfter);
+        }
+    }
+
+    @Override
+    public boolean shouldSwitch() {
+        return switchRequired;
+    }
+
+    @Override
+    public void reset() {
+        firstFailureAt = null;
+        switchRequired = false;
+        log.debug("Long polling master switch policy reset");
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/properties/DurationFailoverProperties.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/properties/DurationFailoverProperties.java
@@ -1,0 +1,23 @@
+package io.ksilisk.telegrambot.longpolling.properties;
+
+import java.time.Duration;
+
+/**
+ * Duration-based failover policy settings.
+ */
+public class DurationFailoverProperties {
+    private static final Duration DEFAULT_SWITCH_AFTER = Duration.ofSeconds(60);
+
+    /**
+     * Continuous failure duration required before switching the current master endpoint.
+     */
+    private Duration switchAfter = DEFAULT_SWITCH_AFTER;
+
+    public Duration getSwitchAfter() {
+        return switchAfter;
+    }
+
+    public void setSwitchAfter(Duration switchAfter) {
+        this.switchAfter = switchAfter;
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/properties/FailoverProperties.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/properties/FailoverProperties.java
@@ -1,0 +1,64 @@
+package io.ksilisk.telegrambot.longpolling.properties;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Long polling failover configuration.
+ *
+ * <p>Failover is driven by long polling failures and switches the active Telegram Bot API
+ * endpoint used by the application.</p>
+ */
+public class FailoverProperties {
+    private static final boolean DEFAULT_ENABLED = true;
+    private static final Policy DEFAULT_POLICY = Policy.DURATION;
+
+    /**
+     * Master switch policy type.
+     */
+    public enum Policy {
+        /**
+         * Switches master after failures continue for a configured duration.
+         */
+        DURATION
+    }
+
+    /**
+     * Whether long polling failover is enabled.
+     */
+    private boolean enabled = DEFAULT_ENABLED;
+
+    /**
+     * Policy used to decide when the current master should be switched.
+     */
+    private Policy policy = DEFAULT_POLICY;
+
+    /**
+     * Duration-based failover settings.
+     */
+    @NestedConfigurationProperty
+    private DurationFailoverProperties duration = new DurationFailoverProperties();
+
+    public DurationFailoverProperties getDuration() {
+        return duration;
+    }
+
+    public void setDuration(DurationFailoverProperties duration) {
+        this.duration = duration;
+    }
+
+    public boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    public void setPolicy(Policy policy) {
+        this.policy = policy;
+    }
+}

--- a/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/properties/LongPollingProperties.java
+++ b/telegram-bot-long-polling/src/main/java/io/ksilisk/telegrambot/longpolling/properties/LongPollingProperties.java
@@ -2,6 +2,7 @@ package io.ksilisk.telegrambot.longpolling.properties;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -57,6 +58,22 @@ public class LongPollingProperties {
      */
     private Duration shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
 
+    /**
+     * Long polling failover settings.
+     *
+     * <p>Controls when and how the active Telegram Bot API endpoint is switched
+     * after long polling failures.</p>
+     */
+    @NestedConfigurationProperty
+    private FailoverProperties failover = new FailoverProperties();
+
+    public FailoverProperties getFailover() {
+        return failover;
+    }
+
+    public void setFailover(FailoverProperties failover) {
+        this.failover = failover;
+    }
 
     public Duration getShutdownTimeout() {
         return shutdownTimeout;

--- a/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/executor/ReportingMasterAwareTelegramBotExecutorTest.java
+++ b/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/executor/ReportingMasterAwareTelegramBotExecutorTest.java
@@ -1,0 +1,73 @@
+package io.ksilisk.telegrambot.longpolling.executor;
+
+import com.pengrad.telegrambot.request.BaseRequest;
+import com.pengrad.telegrambot.response.SendResponse;
+import io.ksilisk.telegrambot.core.exception.request.TelegramRequestException;
+import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.longpolling.failover.MasterManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+
+class ReportingMasterAwareTelegramBotExecutorTest {
+    @Test
+    void shouldRecordSuccessAndReturnResponse() throws TelegramRequestException {
+        TelegramBotExecutor delegate = mock(TelegramBotExecutor.class);
+        MasterManager masterManager = mock(MasterManager.class);
+        ReportingMasterAwareTelegramBotExecutor executor =
+                new ReportingMasterAwareTelegramBotExecutor(delegate, masterManager);
+        TestRequest request = new TestRequest(null);
+        SendResponse response = Mockito.mock(SendResponse.class);
+        when(delegate.execute(request)).thenReturn(response);
+        SendResponse result = executor.execute(request);
+        assertThat(result).isSameAs(response);
+        verify(masterManager).recordSuccess();
+        verify(masterManager, never()).recordFailure(Mockito.any());
+    }
+
+    @Test
+    void shouldRecordFailureAndRethrowRuntimeException() throws TelegramRequestException {
+        TelegramBotExecutor delegate = mock(TelegramBotExecutor.class);
+        MasterManager masterManager = mock(MasterManager.class);
+        ReportingMasterAwareTelegramBotExecutor executor =
+                new ReportingMasterAwareTelegramBotExecutor(delegate, masterManager);
+        TestRequest request = new TestRequest(null);
+        RuntimeException exception = new RuntimeException("boom");
+        when(delegate.execute(request)).thenThrow(exception);
+        assertThatThrownBy(() -> executor.execute(request))
+                .isSameAs(exception);
+        verify(masterManager, never()).recordSuccess();
+        verify(masterManager).recordFailure(same(exception));
+    }
+
+    @Test
+    void shouldRecordFailureWhenTelegramRequestExceptionIsThrown() throws TelegramRequestException {
+        TelegramBotExecutor delegate = mock(TelegramBotExecutor.class);
+        MasterManager masterManager = mock(MasterManager.class);
+        ReportingMasterAwareTelegramBotExecutor executor =
+                new ReportingMasterAwareTelegramBotExecutor(delegate, masterManager);
+        TestRequest request = new TestRequest(null);
+        TelegramRequestException exception = mock(TelegramRequestException.class);
+        when(delegate.execute(request)).thenThrow(exception);
+        assertThatThrownBy(() -> executor.execute(request))
+                .isSameAs(exception);
+        verify(masterManager, never()).recordSuccess();
+        verify(masterManager).recordFailure(Mockito.any());
+    }
+
+    private static final class TestRequest extends BaseRequest<TestRequest, SendResponse> {
+
+        public TestRequest(Class<? extends SendResponse> responseClass) {
+            super(responseClass);
+        }
+
+        @Override
+        public String getMethod() {
+            return "test";
+        }
+    }
+}

--- a/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/failover/impl/DefaultMasterFailureClassifierTest.java
+++ b/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/failover/impl/DefaultMasterFailureClassifierTest.java
@@ -1,0 +1,62 @@
+package io.ksilisk.telegrambot.longpolling.failover.impl;
+
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultMasterFailureClassifierTest {
+
+    private final DefaultMasterFailureClassifier classifier = new DefaultMasterFailureClassifier();
+
+    @Test
+    void shouldReturnTrueForIOException() {
+        IOException exception = new IOException("connection failed");
+
+        assertThat(classifier.isFailure(exception)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenCauseIsIOException() {
+        RuntimeException exception = new RuntimeException(
+                "request failed",
+                new IOException("connection failed")
+        );
+
+        assertThat(classifier.isFailure(exception)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenNestedCauseIsIOException() {
+        RuntimeException exception = new RuntimeException(
+                "outer",
+                new IllegalStateException(
+                        "middle",
+                        new IOException("connection failed")
+                )
+        );
+
+        assertThat(classifier.isFailure(exception)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseForNonIOException() {
+        RuntimeException exception = new RuntimeException("bad request");
+
+        assertThat(classifier.isFailure(exception)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenCauseChainDoesNotContainIOException() {
+        RuntimeException exception = new RuntimeException(
+                "outer",
+                new IllegalStateException("middle")
+        );
+
+        assertThat(classifier.isFailure(exception)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseForNull() {
+        assertThat(classifier.isFailure(null)).isFalse();
+    }
+}

--- a/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/failover/impl/DefaultMasterManagerTest.java
+++ b/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/failover/impl/DefaultMasterManagerTest.java
@@ -1,0 +1,65 @@
+package io.ksilisk.telegrambot.longpolling.failover.impl;
+
+import io.ksilisk.telegrambot.core.executor.resolver.SwitchableTelegramBotApiUrlProvider;
+import io.ksilisk.telegrambot.longpolling.failover.MasterSwitchPolicy;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class DefaultMasterManagerTest {
+
+    @Test
+    void shouldRecordSuccessInSwitchPolicy() {
+        MasterSwitchPolicy switchPolicy = mock(MasterSwitchPolicy.class);
+        SwitchableTelegramBotApiUrlProvider apiUrlProvider = mock(SwitchableTelegramBotApiUrlProvider.class);
+
+        DefaultMasterManager manager = new DefaultMasterManager(switchPolicy, apiUrlProvider);
+
+        manager.recordSuccess();
+
+        verify(switchPolicy).recordSuccess();
+        verifyNoMoreInteractions(apiUrlProvider);
+    }
+
+    @Test
+    void shouldRecordFailureWithoutSwitchingWhenPolicyDoesNotRequireSwitch() {
+        MasterSwitchPolicy switchPolicy = mock(MasterSwitchPolicy.class);
+        SwitchableTelegramBotApiUrlProvider apiUrlProvider = mock(SwitchableTelegramBotApiUrlProvider.class);
+
+        RuntimeException exception = new RuntimeException("connection failed");
+
+        when(switchPolicy.shouldSwitch()).thenReturn(false);
+
+        DefaultMasterManager manager = new DefaultMasterManager(switchPolicy, apiUrlProvider);
+
+        manager.recordFailure(exception);
+
+        verify(switchPolicy).recordFailure(exception);
+        verify(switchPolicy).shouldSwitch();
+        verify(switchPolicy, never()).reset();
+        verify(apiUrlProvider, never()).switchToNext();
+    }
+
+    @Test
+    void shouldSwitchToNextEndpointAndResetPolicyWhenPolicyRequiresSwitch() {
+        MasterSwitchPolicy switchPolicy = mock(MasterSwitchPolicy.class);
+        SwitchableTelegramBotApiUrlProvider apiUrlProvider = mock(SwitchableTelegramBotApiUrlProvider.class);
+
+        RuntimeException exception = new RuntimeException("connection failed");
+
+        when(switchPolicy.shouldSwitch()).thenReturn(true);
+
+        DefaultMasterManager manager = new DefaultMasterManager(switchPolicy, apiUrlProvider);
+
+        manager.recordFailure(exception);
+
+        verify(switchPolicy).recordFailure(exception);
+        verify(switchPolicy).shouldSwitch();
+        verify(apiUrlProvider).switchToNext();
+        verify(switchPolicy).reset();
+    }
+}

--- a/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/failover/policy/duration/DurationBasedMasterSwitchPolicyTest.java
+++ b/telegram-bot-long-polling/src/test/java/io/ksilisk/telegrambot/longpolling/failover/policy/duration/DurationBasedMasterSwitchPolicyTest.java
@@ -1,0 +1,185 @@
+package io.ksilisk.telegrambot.longpolling.failover.policy.duration;
+
+import io.ksilisk.telegrambot.longpolling.failover.MasterFailureClassifier;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DurationBasedMasterSwitchPolicyTest {
+
+    private static final Instant NOW = Instant.parse("2026-05-03T10:00:00Z");
+
+    @Test
+    void shouldRejectNegativeSwitchAfter() {
+        MasterFailureClassifier classifier = throwable -> true;
+
+        assertThatThrownBy(() -> new DurationBasedMasterSwitchPolicy(
+                classifier,
+                Duration.ofMillis(-1),
+                fixedClock(NOW)
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("switchAfter must not be negative");
+    }
+
+    @Test
+    void shouldNotSwitchWhenFailureIsIgnoredByClassifier() {
+        DurationBasedMasterSwitchPolicy policy = new DurationBasedMasterSwitchPolicy(
+                throwable -> false,
+                Duration.ZERO,
+                fixedClock(NOW)
+        );
+
+        policy.recordFailure(new IOException("connection failed"));
+
+        assertThat(policy.shouldSwitch()).isFalse();
+    }
+
+    @Test
+    void shouldSwitchImmediatelyWhenSwitchAfterIsZero() {
+        DurationBasedMasterSwitchPolicy policy = new DurationBasedMasterSwitchPolicy(
+                throwable -> true,
+                Duration.ZERO,
+                fixedClock(NOW)
+        );
+
+        policy.recordFailure(new IOException("connection failed"));
+
+        assertThat(policy.shouldSwitch()).isTrue();
+    }
+
+    @Test
+    void shouldNotSwitchBeforeConfiguredDurationPasses() {
+        MutableClock clock = new MutableClock(NOW);
+
+        DurationBasedMasterSwitchPolicy policy = new DurationBasedMasterSwitchPolicy(
+                throwable -> true,
+                Duration.ofSeconds(60),
+                clock
+        );
+
+        policy.recordFailure(new IOException("connection failed"));
+        assertThat(policy.shouldSwitch()).isFalse();
+
+        clock.advance(Duration.ofSeconds(59));
+        policy.recordFailure(new IOException("connection failed"));
+
+        assertThat(policy.shouldSwitch()).isFalse();
+    }
+
+    @Test
+    void shouldSwitchWhenConfiguredDurationPasses() {
+        MutableClock clock = new MutableClock(NOW);
+
+        DurationBasedMasterSwitchPolicy policy = new DurationBasedMasterSwitchPolicy(
+                throwable -> true,
+                Duration.ofSeconds(60),
+                clock
+        );
+
+        policy.recordFailure(new IOException("connection failed"));
+        assertThat(policy.shouldSwitch()).isFalse();
+
+        clock.advance(Duration.ofSeconds(60));
+        policy.recordFailure(new IOException("connection failed"));
+
+        assertThat(policy.shouldSwitch()).isTrue();
+    }
+
+    @Test
+    void shouldResetSwitchStateOnSuccess() {
+        DurationBasedMasterSwitchPolicy policy = new DurationBasedMasterSwitchPolicy(
+                throwable -> true,
+                Duration.ZERO,
+                fixedClock(NOW)
+        );
+
+        policy.recordFailure(new IOException("connection failed"));
+        assertThat(policy.shouldSwitch()).isTrue();
+
+        policy.recordSuccess();
+
+        assertThat(policy.shouldSwitch()).isFalse();
+    }
+
+    @Test
+    void shouldResetSwitchStateOnReset() {
+        DurationBasedMasterSwitchPolicy policy = new DurationBasedMasterSwitchPolicy(
+                throwable -> true,
+                Duration.ZERO,
+                fixedClock(NOW)
+        );
+
+        policy.recordFailure(new IOException("connection failed"));
+        assertThat(policy.shouldSwitch()).isTrue();
+
+        policy.reset();
+
+        assertThat(policy.shouldSwitch()).isFalse();
+    }
+
+    @Test
+    void shouldOpenNewFailureWindowAfterReset() {
+        MutableClock clock = new MutableClock(NOW);
+
+        DurationBasedMasterSwitchPolicy policy = new DurationBasedMasterSwitchPolicy(
+                throwable -> true,
+                Duration.ofSeconds(60),
+                clock
+        );
+
+        policy.recordFailure(new IOException("first failure"));
+        clock.advance(Duration.ofSeconds(30));
+        policy.reset();
+
+        policy.recordFailure(new IOException("second failure"));
+        clock.advance(Duration.ofSeconds(30));
+        policy.recordFailure(new IOException("third failure"));
+
+        assertThat(policy.shouldSwitch()).isFalse();
+
+        clock.advance(Duration.ofSeconds(30));
+        policy.recordFailure(new IOException("fourth failure"));
+
+        assertThat(policy.shouldSwitch()).isTrue();
+    }
+
+    private static Clock fixedClock(Instant instant) {
+        return Clock.fixed(instant, ZoneOffset.UTC);
+    }
+
+    private static final class MutableClock extends Clock {
+
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return Clock.fixed(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/config/transport/client/OkHttpTelegramClientConfiguration.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/config/transport/client/OkHttpTelegramClientConfiguration.java
@@ -1,79 +1,56 @@
 package io.ksilisk.telegrambot.autoconfigure.config.transport.client;
 
-import com.pengrad.telegrambot.utility.BotUtils;
 import io.ksilisk.telegrambot.autoconfigure.condition.client.OkHttpSelectedCondition;
 import io.ksilisk.telegrambot.autoconfigure.customizer.OkHttpClientCustomizer;
-import io.ksilisk.telegrambot.autoconfigure.executor.OkHttpTelegramBotExecutor;
-import io.ksilisk.telegrambot.autoconfigure.executor.OkHttpTelegramBotFileClient;
+import io.ksilisk.telegrambot.autoconfigure.executor.factory.OkHttpTelegramBotClientFactory;
 import io.ksilisk.telegrambot.autoconfigure.properties.TelegramBotProperties;
+import io.ksilisk.telegrambot.core.executor.TelegramBotClientFactory;
 import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
 import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
 import io.ksilisk.telegrambot.core.executor.retry.RetryDelayStrategy;
+import io.ksilisk.telegrambot.core.executor.retry.RetryingTelegramBotClientFactory;
 import io.ksilisk.telegrambot.core.executor.retry.impl.CompositeRetryRule;
 import io.ksilisk.telegrambot.core.file.TelegramBotFileClient;
-import io.ksilisk.telegrambot.core.properties.OkHttpClientProperties;
-import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
-import static io.ksilisk.telegrambot.autoconfigure.config.transport.client.TelegramClientRetryConfiguration.buildRetryingTelegramBotExecutor;
-
 @Configuration(proxyBeanMethods = false)
 @Conditional(OkHttpSelectedCondition.class)
 public class OkHttpTelegramClientConfiguration {
-    private final TelegramBotProperties properties;
     private final TelegramBotApiUrlProvider apiUrlProvider;
 
-    public OkHttpTelegramClientConfiguration(TelegramBotProperties properties, TelegramBotApiUrlProvider apiUrlProvider) {
-        this.properties = properties;
+    public OkHttpTelegramClientConfiguration(TelegramBotApiUrlProvider apiUrlProvider) {
         this.apiUrlProvider = apiUrlProvider;
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public OkHttpClient okHttpClient(ObjectProvider<OkHttpClientCustomizer> okHttpClientCustomizers) {
-        OkHttpClientProperties props = properties.getClient().getOkhttp();
+    @ConditionalOnMissingBean(TelegramBotClientFactory.class)
+    public TelegramBotClientFactory telegramBotClientFactory(ObjectProvider<OkHttpClientCustomizer> okHttpClientCustomizers,
+                                                             ObjectProvider<CompositeRetryRule> compositeRetryRule,
+                                                             ObjectProvider<RetryDelayStrategy> retryDelayStrategy,
+                                                             TelegramBotProperties properties) {
+        OkHttpTelegramBotClientFactory rawFactory = new OkHttpTelegramBotClientFactory(properties.getClient().getOkhttp(),
+                okHttpClientCustomizers.orderedStream().toList(), apiUrlProvider);
 
-        OkHttpClient.Builder builder = new OkHttpClient.Builder()
-                .connectTimeout(props.getConnectTimeout())
-                .readTimeout(props.getReadTimeout())
-                .writeTimeout(props.getWriteTimeout())
-                .callTimeout(props.getCallTimeout());
-
-        okHttpClientCustomizers.orderedStream().forEach(c -> c.customize(builder));
-        return builder.build();
+        return new RetryingTelegramBotClientFactory(rawFactory,
+                properties.getClient().getRetry().getEnabled(),
+                compositeRetryRule.getIfAvailable(),
+                retryDelayStrategy.getIfAvailable());
     }
 
     @Bean
     @ConditionalOnMissingBean(TelegramBotExecutor.class)
-    public TelegramBotExecutor telegramBotExecutor(OkHttpClient okHttpClient,
-                                                   ObjectProvider<CompositeRetryRule> compositeRetryRule,
-                                                   ObjectProvider<RetryDelayStrategy> retryDelayStrategy) {
-        TelegramBotExecutor executor =
-                new OkHttpTelegramBotExecutor(okHttpClient, BotUtils.GSON, apiUrlProvider.getApiUrl());
-
-        if (properties.getClient().getRetry().getEnabled()) {
-            return buildRetryingTelegramBotExecutor(executor,
-                    compositeRetryRule.getIfAvailable(),
-                    retryDelayStrategy.getIfAvailable());
-        }
-
-        return executor;
+    public TelegramBotExecutor telegramBotExecutor(TelegramBotClientFactory telegramBotClientFactory) {
+        return telegramBotClientFactory.createExecutor();
     }
 
     @Bean
     @ConditionalOnMissingBean(TelegramBotFileClient.class)
-    public TelegramBotFileClient telegramBotFileClient(
-            OkHttpClient okHttpClient,
-            TelegramBotExecutor telegramBotExecutor
-    ) {
-        return new OkHttpTelegramBotFileClient(
-                okHttpClient,
-                apiUrlProvider.getFileUrl(),
-                telegramBotExecutor
-        );
+    public TelegramBotFileClient telegramBotFileClient(TelegramBotClientFactory clientFactory,
+                                                       TelegramBotExecutor telegramBotExecutor) {
+        return clientFactory.createFileClient(telegramBotExecutor);
     }
 }

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/config/transport/client/SpringTelegramClientConfiguration.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/config/transport/client/SpringTelegramClientConfiguration.java
@@ -1,13 +1,13 @@
 package io.ksilisk.telegrambot.autoconfigure.config.transport.client;
 
-import com.pengrad.telegrambot.utility.BotUtils;
 import io.ksilisk.telegrambot.autoconfigure.condition.client.SpringSelectedCondition;
-import io.ksilisk.telegrambot.autoconfigure.executor.RestClientTelegramBotExecutor;
-import io.ksilisk.telegrambot.autoconfigure.executor.RestClientTelegramBotFileClient;
+import io.ksilisk.telegrambot.autoconfigure.executor.factory.RestClientTelegramBotClientFactory;
 import io.ksilisk.telegrambot.autoconfigure.properties.TelegramBotProperties;
+import io.ksilisk.telegrambot.core.executor.TelegramBotClientFactory;
 import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
 import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
 import io.ksilisk.telegrambot.core.executor.retry.RetryDelayStrategy;
+import io.ksilisk.telegrambot.core.executor.retry.RetryingTelegramBotClientFactory;
 import io.ksilisk.telegrambot.core.executor.retry.impl.CompositeRetryRule;
 import io.ksilisk.telegrambot.core.file.TelegramBotFileClient;
 import org.springframework.beans.factory.ObjectProvider;
@@ -15,65 +15,42 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.json.GsonHttpMessageConverter;
 import org.springframework.web.client.RestClient;
-
-import static io.ksilisk.telegrambot.autoconfigure.config.transport.client.TelegramClientRetryConfiguration.buildRetryingTelegramBotExecutor;
 
 @Configuration(proxyBeanMethods = false)
 @Conditional(SpringSelectedCondition.class)
 public class SpringTelegramClientConfiguration {
 
-    private final TelegramBotProperties properties;
     private final TelegramBotApiUrlProvider apiUrlProvider;
 
-    public SpringTelegramClientConfiguration(
-            TelegramBotProperties properties,
-            TelegramBotApiUrlProvider apiUrlProvider
-    ) {
-        this.properties = properties;
+    public SpringTelegramClientConfiguration(TelegramBotApiUrlProvider apiUrlProvider) {
         this.apiUrlProvider = apiUrlProvider;
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public RestClient restClient(RestClient.Builder builder) {
-        return builder
-                .baseUrl(apiUrlProvider.getApiUrl())
-                .messageConverters(converters -> {
-                    converters.clear();
-                    converters.add(new GsonHttpMessageConverter(BotUtils.GSON));
-                })
-                .build();
+    @ConditionalOnMissingBean(TelegramBotClientFactory.class)
+    public TelegramBotClientFactory telegramBotClientFactory(RestClient.Builder restClientBuilder,
+                                                             ObjectProvider<CompositeRetryRule> compositeRetryRule,
+                                                             ObjectProvider<RetryDelayStrategy> retryDelayStrategy,
+                                                             TelegramBotProperties properties) {
+        TelegramBotClientFactory rawFactory = new RestClientTelegramBotClientFactory(restClientBuilder, apiUrlProvider);
+
+        return new RetryingTelegramBotClientFactory(rawFactory,
+                properties.getClient().getRetry().getEnabled(),
+                compositeRetryRule.getIfAvailable(),
+                retryDelayStrategy.getIfAvailable());
     }
 
     @Bean
     @ConditionalOnMissingBean(TelegramBotExecutor.class)
-    public TelegramBotExecutor telegramBotExecutor(RestClient restClient,
-                                                   ObjectProvider<CompositeRetryRule> compositeRetryRule,
-                                                   ObjectProvider<RetryDelayStrategy> retryDelayStrategy) {
-        TelegramBotExecutor executor =
-                new RestClientTelegramBotExecutor(restClient, apiUrlProvider.getApiUrl());
-
-        if (properties.getClient().getRetry().getEnabled()) {
-            return buildRetryingTelegramBotExecutor(executor,
-                    compositeRetryRule.getIfAvailable(),
-                    retryDelayStrategy.getIfAvailable());
-        }
-
-        return executor;
+    public TelegramBotExecutor telegramBotExecutor(TelegramBotClientFactory clientFactory) {
+        return clientFactory.createExecutor();
     }
 
     @Bean
     @ConditionalOnMissingBean(TelegramBotFileClient.class)
-    public TelegramBotFileClient telegramBotFileClient(
-            RestClient restClient,
-            TelegramBotExecutor telegramBotExecutor
-    ) {
-        return new RestClientTelegramBotFileClient(
-                restClient,
-                apiUrlProvider.getFileUrl(),
-                telegramBotExecutor
-        );
+    public TelegramBotFileClient telegramBotFileClient(TelegramBotClientFactory clientFactory,
+                                                       TelegramBotExecutor telegramBotExecutor) {
+        return clientFactory.createFileClient(telegramBotExecutor);
     }
 }

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/config/transport/client/TelegramClientConfiguration.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/config/transport/client/TelegramClientConfiguration.java
@@ -1,5 +1,6 @@
 package io.ksilisk.telegrambot.autoconfigure.config.transport.client;
 
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -10,5 +11,6 @@ import org.springframework.context.annotation.Import;
         OkHttpTelegramClientConfiguration.class,
         SpringTelegramClientConfiguration.class
 })
+@AutoConfigureOrder
 public class TelegramClientConfiguration {
 }

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/config/transport/client/TelegramClientCoreConfiguration.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/config/transport/client/TelegramClientCoreConfiguration.java
@@ -1,7 +1,8 @@
 package io.ksilisk.telegrambot.autoconfigure.config.transport.client;
 
 import io.ksilisk.telegrambot.autoconfigure.properties.TelegramBotProperties;
-import io.ksilisk.telegrambot.core.executor.resolver.DefaultTelegramBotApiUrlProvider;
+import io.ksilisk.telegrambot.core.executor.resolver.DefaultSwitchableTelegramBotApiUrlProvider;
+import io.ksilisk.telegrambot.core.executor.resolver.SwitchableTelegramBotApiUrlProvider;
 import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -12,10 +13,11 @@ public class TelegramClientCoreConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(TelegramBotApiUrlProvider.class)
-    public TelegramBotApiUrlProvider telegramBotApiUrlProvider(TelegramBotProperties properties) {
-        return new DefaultTelegramBotApiUrlProvider(
+    public SwitchableTelegramBotApiUrlProvider telegramBotApiUrlProvider(TelegramBotProperties properties) {
+        return new DefaultSwitchableTelegramBotApiUrlProvider(
                 properties.getToken(),
-                properties.getUseTestServer()
+                properties.getUseTestServer(),
+                properties.getClient().getApi().getEndpoints()
         );
     }
 }

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/OkHttpTelegramBotExecutor.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/OkHttpTelegramBotExecutor.java
@@ -6,6 +6,7 @@ import com.pengrad.telegrambot.request.BaseRequest;
 import com.pengrad.telegrambot.response.BaseResponse;
 import io.ksilisk.telegrambot.core.exception.request.TelegramRequestException;
 import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
 import okhttp3.FormBody;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -23,12 +24,12 @@ public class OkHttpTelegramBotExecutor implements TelegramBotExecutor {
 
     private final OkHttpClient okHttpClient;
     private final Gson gson;
-    private final String baseUrl;
+    private final TelegramBotApiUrlProvider apiUrlProvider;
 
-    public OkHttpTelegramBotExecutor(OkHttpClient okHttpClient, Gson gson, String baseUrl) {
+    public OkHttpTelegramBotExecutor(OkHttpClient okHttpClient, Gson gson, TelegramBotApiUrlProvider urlProvider) {
         this.okHttpClient = okHttpClient;
         this.gson = gson;
-        this.baseUrl = baseUrl;
+        this.apiUrlProvider = urlProvider;
     }
 
     @Override
@@ -67,7 +68,7 @@ public class OkHttpTelegramBotExecutor implements TelegramBotExecutor {
     }
 
     private Request createRequest(BaseRequest<?, ?> request) {
-        String url = baseUrl + request.getMethod();
+        String url = apiUrlProvider.getApiUrl() + request.getMethod();
         RequestBody requestBody = createRequestBody(request);
 
         return new Request.Builder()

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/OkHttpTelegramBotFileClient.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/OkHttpTelegramBotFileClient.java
@@ -2,6 +2,7 @@ package io.ksilisk.telegrambot.autoconfigure.executor;
 
 import io.ksilisk.telegrambot.core.exception.file.TelegramFileDownloadException;
 import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
 import io.ksilisk.telegrambot.core.file.TelegramBotFileClient;
 import io.ksilisk.telegrambot.core.file.TelegramBotFiles;
 import okhttp3.Call;
@@ -16,20 +17,20 @@ import java.io.InputStream;
 public class OkHttpTelegramBotFileClient implements TelegramBotFileClient {
 
     private final OkHttpClient okHttpClient;
-    private final String baseUrl;
+    private final TelegramBotApiUrlProvider urlProvider;
     private final TelegramBotExecutor telegramBotExecutor;
 
     public OkHttpTelegramBotFileClient(OkHttpClient okHttpClient,
-                                       String baseUrl,
+                                       TelegramBotApiUrlProvider apiUrlProvider,
                                        TelegramBotExecutor telegramBotExecutor) {
         this.okHttpClient = okHttpClient;
-        this.baseUrl = baseUrl;
+        this.urlProvider = apiUrlProvider;
         this.telegramBotExecutor = telegramBotExecutor;
     }
 
     @Override
-    public byte[] downloadByPath(String filePath)  {
-        String url = TelegramBotFiles.buildFileUrl(baseUrl, filePath);
+    public byte[] downloadByPath(String filePath) {
+        String url = TelegramBotFiles.buildFileUrl(urlProvider.getFileUrl(), filePath);
 
         Request request = new Request.Builder()
                 .get()
@@ -54,7 +55,7 @@ public class OkHttpTelegramBotFileClient implements TelegramBotFileClient {
 
     @Override
     public InputStream openStreamByPath(String filePath) {
-        String url = TelegramBotFiles.buildFileUrl(baseUrl, filePath);
+        String url = TelegramBotFiles.buildFileUrl(urlProvider.getFileUrl(), filePath);
 
         Request request = new Request.Builder()
                 .get()

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/RestClientTelegramBotExecutor.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/RestClientTelegramBotExecutor.java
@@ -5,6 +5,7 @@ import com.pengrad.telegrambot.request.BaseRequest;
 import com.pengrad.telegrambot.response.BaseResponse;
 import io.ksilisk.telegrambot.core.exception.request.TelegramRequestException;
 import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.web.client.RestClient;
@@ -16,11 +17,11 @@ import java.util.Map;
 
 public class RestClientTelegramBotExecutor implements TelegramBotExecutor {
     private final RestClient restClient;
-    private final String baseUrl;
+    private final TelegramBotApiUrlProvider urlProvider;
 
-    public RestClientTelegramBotExecutor(RestClient restClient, String baseUrl) {
+    public RestClientTelegramBotExecutor(RestClient restClient, TelegramBotApiUrlProvider apiUrlProvider) {
         this.restClient = restClient;
-        this.baseUrl = baseUrl;
+        this.urlProvider = apiUrlProvider;
     }
 
     @Override
@@ -90,7 +91,7 @@ public class RestClientTelegramBotExecutor implements TelegramBotExecutor {
         }
 
         return restClient.post()
-                .uri(baseUrl + request.getMethod())
+                .uri(urlProvider.getApiUrl() + request.getMethod())
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(builder.build())
                 .retrieve()
@@ -100,7 +101,7 @@ public class RestClientTelegramBotExecutor implements TelegramBotExecutor {
     private <T extends BaseRequest<T, R>, R extends BaseResponse> R executeFormRequest(BaseRequest<T, R> request) {
 
         return restClient.post()
-                .uri(baseUrl + request.getMethod())
+                .uri(urlProvider.getApiUrl() + request.getMethod())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(request.getParameters())
                 .retrieve()

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/RestClientTelegramBotFileClient.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/RestClientTelegramBotFileClient.java
@@ -2,6 +2,7 @@ package io.ksilisk.telegrambot.autoconfigure.executor;
 
 import io.ksilisk.telegrambot.core.exception.file.TelegramFileDownloadException;
 import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
 import io.ksilisk.telegrambot.core.file.TelegramBotFileClient;
 import io.ksilisk.telegrambot.core.file.TelegramBotFiles;
 import org.springframework.http.HttpMethod;
@@ -12,20 +13,20 @@ import java.io.InputStream;
 
 public class RestClientTelegramBotFileClient implements TelegramBotFileClient {
     private final RestClient restClient;
-    private final String baseUrl;
+    private final TelegramBotApiUrlProvider urlProvider;
     private final TelegramBotExecutor telegramBotExecutor;
 
     public RestClientTelegramBotFileClient(RestClient restClient,
-                                           String baseUrl,
+                                           TelegramBotApiUrlProvider apiUrlProvider,
                                            TelegramBotExecutor telegramBotExecutor) {
         this.restClient = restClient;
-        this.baseUrl = baseUrl;
+        this.urlProvider = apiUrlProvider;
         this.telegramBotExecutor = telegramBotExecutor;
     }
 
     @Override
     public byte[] downloadByPath(String filePath) {
-        String url = TelegramBotFiles.buildFileUrl(baseUrl, filePath);
+        String url = TelegramBotFiles.buildFileUrl(urlProvider.getFileUrl(), filePath);
 
         try {
             return restClient.get()
@@ -39,7 +40,7 @@ public class RestClientTelegramBotFileClient implements TelegramBotFileClient {
 
     @Override
     public InputStream openStreamByPath(String filePath) {
-        String url = TelegramBotFiles.buildFileUrl(baseUrl, filePath);
+        String url = TelegramBotFiles.buildFileUrl(urlProvider.getFileUrl(), filePath);
 
         try {
             return restClient.method(HttpMethod.GET)

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/factory/OkHttpTelegramBotClientFactory.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/factory/OkHttpTelegramBotClientFactory.java
@@ -1,0 +1,49 @@
+package io.ksilisk.telegrambot.autoconfigure.executor.factory;
+
+import com.pengrad.telegrambot.utility.BotUtils;
+import io.ksilisk.telegrambot.autoconfigure.customizer.OkHttpClientCustomizer;
+import io.ksilisk.telegrambot.autoconfigure.executor.OkHttpTelegramBotExecutor;
+import io.ksilisk.telegrambot.autoconfigure.executor.OkHttpTelegramBotFileClient;
+import io.ksilisk.telegrambot.core.executor.TelegramBotClientFactory;
+import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
+import io.ksilisk.telegrambot.core.file.TelegramBotFileClient;
+import io.ksilisk.telegrambot.core.properties.OkHttpClientProperties;
+import okhttp3.OkHttpClient;
+
+import java.util.List;
+
+public class OkHttpTelegramBotClientFactory implements TelegramBotClientFactory {
+    private final OkHttpClientProperties properties;
+    private final List<OkHttpClientCustomizer> customizers;
+    private final TelegramBotApiUrlProvider telegramBotApiUrlProvider;
+
+    public OkHttpTelegramBotClientFactory(OkHttpClientProperties properties,
+                                          List<OkHttpClientCustomizer> okHttpClientCustomizers,
+                                          TelegramBotApiUrlProvider telegramBotApiUrlProvider) {
+        this.properties = properties;
+        this.customizers = okHttpClientCustomizers;
+        this.telegramBotApiUrlProvider = telegramBotApiUrlProvider;
+    }
+
+    @Override
+    public TelegramBotExecutor createExecutor() {
+        return new OkHttpTelegramBotExecutor(createOkHttpClient(), BotUtils.GSON, telegramBotApiUrlProvider);
+    }
+
+    private OkHttpClient createOkHttpClient() {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .connectTimeout(properties.getConnectTimeout())
+                .readTimeout(properties.getReadTimeout())
+                .writeTimeout(properties.getWriteTimeout())
+                .callTimeout(properties.getCallTimeout());
+        customizers.forEach(customizer -> customizer.customize(builder));
+        return builder.build();
+
+    }
+
+    @Override
+    public TelegramBotFileClient createFileClient(TelegramBotExecutor telegramBotExecutor) {
+        return new OkHttpTelegramBotFileClient(createOkHttpClient(), telegramBotApiUrlProvider, telegramBotExecutor);
+    }
+}

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/factory/RestClientTelegramBotClientFactory.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/executor/factory/RestClientTelegramBotClientFactory.java
@@ -1,0 +1,43 @@
+package io.ksilisk.telegrambot.autoconfigure.executor.factory;
+
+import com.pengrad.telegrambot.utility.BotUtils;
+import io.ksilisk.telegrambot.autoconfigure.executor.RestClientTelegramBotExecutor;
+import io.ksilisk.telegrambot.autoconfigure.executor.RestClientTelegramBotFileClient;
+import io.ksilisk.telegrambot.core.executor.TelegramBotClientFactory;
+import io.ksilisk.telegrambot.core.executor.TelegramBotExecutor;
+import io.ksilisk.telegrambot.core.executor.resolver.TelegramBotApiUrlProvider;
+import io.ksilisk.telegrambot.core.file.TelegramBotFileClient;
+import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.web.client.RestClient;
+
+public class RestClientTelegramBotClientFactory implements TelegramBotClientFactory {
+    private final RestClient.Builder restClientBuilder;
+    private final TelegramBotApiUrlProvider telegramBotApiUrlProvider;
+
+    public RestClientTelegramBotClientFactory(RestClient.Builder restClientBuilder,
+                                              TelegramBotApiUrlProvider telegramBotApiUrlProvider) {
+        this.restClientBuilder = restClientBuilder;
+        this.telegramBotApiUrlProvider = telegramBotApiUrlProvider;
+    }
+
+    @Override
+    public TelegramBotExecutor createExecutor() {
+        return new RestClientTelegramBotExecutor(createRestClient(), telegramBotApiUrlProvider);
+
+    }
+
+    @Override
+    public TelegramBotFileClient createFileClient(TelegramBotExecutor telegramBotExecutor) {
+        return new RestClientTelegramBotFileClient(createRestClient(), telegramBotApiUrlProvider, telegramBotExecutor);
+    }
+
+    private RestClient createRestClient() {
+        return restClientBuilder
+                .clone()
+                .messageConverters(converters -> {
+                    converters.clear();
+                    converters.add(new GsonHttpMessageConverter(BotUtils.GSON));
+                })
+                .build();
+    }
+}

--- a/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/properties/ClientProperties.java
+++ b/telegram-bot-spring-boot-autoconfigure/src/main/java/io/ksilisk/telegrambot/autoconfigure/properties/ClientProperties.java
@@ -1,5 +1,6 @@
 package io.ksilisk.telegrambot.autoconfigure.properties;
 
+import io.ksilisk.telegrambot.core.properties.ClientApiProperties;
 import io.ksilisk.telegrambot.core.properties.ClientRetryProperties;
 import io.ksilisk.telegrambot.core.properties.OkHttpClientProperties;
 import jakarta.validation.Valid;
@@ -50,11 +51,29 @@ public class ClientProperties {
     @NestedConfigurationProperty
     private ClientRetryProperties retry = new ClientRetryProperties();
 
+    /**
+     * Telegram Bot API client settings.
+     */
+    @Valid
+    @NotNull
+    @NestedConfigurationProperty
+    private ClientApiProperties api = new ClientApiProperties();
+
+    public ClientApiProperties getApi() {
+        return api;
+    }
+
+    public void setApi(ClientApiProperties api) {
+        this.api = api;
+    }
+
     public ClientImplementation getImplementation() {
         return implementation;
     }
 
-    public void setImplementation(ClientImplementation implementation) { this.implementation = implementation;}
+    public void setImplementation(ClientImplementation implementation) {
+        this.implementation = implementation;
+    }
 
     public OkHttpClientProperties getOkhttp() {
         return okhttp;


### PR DESCRIPTION
## 📝 Summary

New failover for long-polling mode (suitable for multiple telegram bot api instances).
It switches endpoints in runtime without restarting and reconfiguring application.

## 🔗 Related Issue

- Closes #103 

---

## 📦 Type of Change

Mark the type of change this PR introduces:

- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Tests only
- [x] 📚 Documentation
- [ ] ⚠️ Breaking change

---

## ✅ Checklist

Before submitting, please ensure that:

- [x] The branch name follows the convention (`feature/#id-description`)
- [x] The PR title clearly describes the change
- [x] The PR is linked to an issue (`Closes #...`)
- [x] Commits are meaningful and well-structured
- [x] Code follows the project style and structure
- [x] Unit tests have been added or updated
- [x] All tests pass locally (`mvn clean verify`)
- [x] Documentation / Javadoc updated if necessary

---
