### PR TITLE
fix: support Executor implementations for update delivery

### DIFF
--- a/telegram-bot-core/README.md
+++ b/telegram-bot-core/README.md
@@ -72,6 +72,19 @@ Main contracts:
 
 Default implementation uses a configurable thread pool and is shared across transports.
 
+The factory returns a `java.util.concurrent.Executor`, so Spring applications can supply a
+managed `ThreadPoolTaskExecutor` and configure a `TaskDecorator` for context propagation:
+
+```java
+@Bean
+DeliveryThreadPoolExecutorFactory deliveryThreadPoolExecutorFactory(ThreadPoolTaskExecutor executor) {
+    return () -> executor;
+}
+```
+
+The default factory still creates and shuts down a `ThreadPoolExecutor`. Executors managed by
+an application container are not shut down by `DefaultUpdateDelivery`.
+
 ---
 
 ### **Interceptors**

--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/delivery/DefaultUpdateDelivery.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/delivery/DefaultUpdateDelivery.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -18,18 +19,18 @@ public class DefaultUpdateDelivery implements UpdateDelivery {
     private static final Logger log = LoggerFactory.getLogger(DefaultUpdateDelivery.class);
 
     private final UpdateDispatcher updateDispatcher;
-    private final ExecutorService executorService;
+    private final Executor executor;
     private final DeliveryProperties deliveryProperties;
     private final CompositeUpdateInterceptor compositeUpdateInterceptor;
     private final CompositeUpdateExceptionHandler exceptionHandler;
 
     public DefaultUpdateDelivery(UpdateDispatcher updateDispatcher,
-                                 ExecutorService executorService,
+                                 Executor executor,
                                  DeliveryProperties deliveryProperties,
                                  CompositeUpdateInterceptor compositeUpdateInterceptor,
                                  CompositeUpdateExceptionHandler exceptionHandler) {
         this.updateDispatcher = updateDispatcher;
-        this.executorService = executorService;
+        this.executor = executor;
         this.deliveryProperties = deliveryProperties;
         this.compositeUpdateInterceptor = compositeUpdateInterceptor;
         this.exceptionHandler = exceptionHandler;
@@ -48,7 +49,7 @@ public class DefaultUpdateDelivery implements UpdateDelivery {
                 }
             };
 
-            executorService.submit(() -> capture.wrap(processUpdateWithMDC).run());
+            executor.execute(capture.wrap(processUpdateWithMDC));
         }
     }
 
@@ -72,6 +73,11 @@ public class DefaultUpdateDelivery implements UpdateDelivery {
 
     public void stop() {
         log.info("Stopping Update Delivery");
+        if (!(executor instanceof ExecutorService executorService)) {
+            log.info("Skipping executor shutdown because it is managed externally: {}",
+                    executor.getClass().getName());
+            return;
+        }
         executorService.shutdown();
         try {
             if (!executorService.awaitTermination(

--- a/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/delivery/DeliveryThreadPoolExecutorFactory.java
+++ b/telegram-bot-core/src/main/java/io/ksilisk/telegrambot/core/delivery/DeliveryThreadPoolExecutorFactory.java
@@ -1,19 +1,22 @@
 package io.ksilisk.telegrambot.core.delivery;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
- * Factory for creating the {@link ThreadPoolExecutor} used by the delivery pipeline.
+ * Factory for creating the executor used by the delivery pipeline.
  *
  * <p>Implementations may customize thread count, queue type, rejection policy
  * or thread naming. The returned executor must be fully initialized and ready
- * for use.</p>
+ * for use. Spring applications may return any {@link Executor}, such as a
+ * {@code ThreadPoolTaskExecutor}; the default implementation returns a
+ * {@link ThreadPoolExecutor}.</p>
  */
 public interface DeliveryThreadPoolExecutorFactory {
     /**
-     * Build a new {@link ThreadPoolExecutor} instance.
+     * Build a new executor instance.
      *
      * @return a configured executor, never {@code null}
      */
-    ThreadPoolExecutor buildThreadPoolExecutor();
+    Executor buildThreadPoolExecutor();
 }

--- a/telegram-bot-core/src/test/java/io/ksilisk/telegrambot/core/delivery/DefaultUpdateDeliveryTest.java
+++ b/telegram-bot-core/src/test/java/io/ksilisk/telegrambot/core/delivery/DefaultUpdateDeliveryTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -59,11 +59,11 @@ class DefaultUpdateDeliveryTest {
         List<Runnable> submittedTasks = new ArrayList<>();
 
         // Capture submitted Runnable tasks instead of actually running them on a real executor
-        when(executorService.submit(any(Runnable.class))).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             Runnable task = invocation.getArgument(0);
             submittedTasks.add(task);
-            return mock(Future.class);
-        });
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
 
         when(compositeUpdateInterceptor.intercept(update1)).thenReturn(update1); // intercepted but same instance is fine
         when(compositeUpdateInterceptor.intercept(update2)).thenReturn(update2);
@@ -94,11 +94,11 @@ class DefaultUpdateDeliveryTest {
         Update update = mock(Update.class);
         List<Runnable> submittedTasks = new ArrayList<>();
 
-        when(executorService.submit(any(Runnable.class))).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             Runnable task = invocation.getArgument(0);
             submittedTasks.add(task);
-            return mock(Future.class);
-        });
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
 
         // Interceptor decides to skip this update
         when(compositeUpdateInterceptor.intercept(update)).thenReturn(null);
@@ -126,15 +126,44 @@ class DefaultUpdateDeliveryTest {
     }
 
     @Test
+    void shouldSupportExecutorImplementationsThatAreNotExecutorServices() throws Exception {
+        Executor executor = mock(Executor.class);
+        DefaultUpdateDelivery executorDelivery = new DefaultUpdateDelivery(
+                updateDispatcher,
+                executor,
+                deliveryProperties,
+                compositeUpdateInterceptor,
+                exceptionHandler
+        );
+        Update update = mock(Update.class);
+        List<Runnable> submittedTasks = new ArrayList<>();
+
+        doAnswer(invocation -> {
+            submittedTasks.add(invocation.getArgument(0));
+            return null;
+        }).when(executor).execute(any(Runnable.class));
+        when(compositeUpdateInterceptor.intercept(update)).thenReturn(update);
+
+        executorDelivery.deliver(List.of(update));
+        submittedTasks.get(0).run();
+        executorDelivery.stop();
+
+        verify(executor).execute(any(Runnable.class));
+        verify(compositeUpdateInterceptor).intercept(update);
+        verify(updateDispatcher).dispatch(update);
+        verifyNoInteractions(exceptionHandler);
+    }
+
+    @Test
     void shouldInvokeExceptionHandlerWhenInterceptorThrows() throws Exception {
         Update update = mock(Update.class);
         List<Runnable> submittedTasks = new ArrayList<>();
 
-        when(executorService.submit(any(Runnable.class))).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             Runnable task = invocation.getArgument(0);
             submittedTasks.add(task);
-            return mock(Future.class);
-        });
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
 
         RuntimeException ex = new RuntimeException("interceptor failed");
         when(compositeUpdateInterceptor.intercept(update)).thenThrow(ex);
@@ -153,11 +182,11 @@ class DefaultUpdateDeliveryTest {
         Update update = mock(Update.class);
         List<Runnable> submittedTasks = new ArrayList<>();
 
-        when(executorService.submit(any(Runnable.class))).thenAnswer(invocation -> {
+        doAnswer(invocation -> {
             Runnable task = invocation.getArgument(0);
             submittedTasks.add(task);
-            return mock(Future.class);
-        });
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
 
         when(compositeUpdateInterceptor.intercept(update)).thenReturn(update);
 

--- a/telegram-bot-observability/src/main/java/io/ksilisk/telegrambot/observability/bpp/DeliveryThreadPoolExecutorFactoryObservabilityBeanPostProcessor.java
+++ b/telegram-bot-observability/src/main/java/io/ksilisk/telegrambot/observability/bpp/DeliveryThreadPoolExecutorFactoryObservabilityBeanPostProcessor.java
@@ -19,7 +19,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * BeanPostProcessor that instruments {@link DeliveryThreadPoolExecutorFactory}
- * to register gauges for the delivery {@link ThreadPoolExecutor}.
+ * to register gauges for the delivery {@link ThreadPoolExecutor}. Executors
+ * supplied by other implementations are left unchanged.
  */
 public final class DeliveryThreadPoolExecutorFactoryObservabilityBeanPostProcessor
         implements BeanPostProcessor, PriorityOrdered {

--- a/telegram-bot-observability/src/main/java/io/ksilisk/telegrambot/observability/bpp/DeliveryThreadPoolExecutorMetricsInterceptor.java
+++ b/telegram-bot-observability/src/main/java/io/ksilisk/telegrambot/observability/bpp/DeliveryThreadPoolExecutorMetricsInterceptor.java
@@ -12,7 +12,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Registers delivery thread pool gauges for a {@link ThreadPoolExecutor}
- * created by {@link DeliveryThreadPoolExecutorFactory}.
+ * created by {@link DeliveryThreadPoolExecutorFactory}. Executors of other
+ * types are returned without instrumentation.
  */
 final class DeliveryThreadPoolExecutorMetricsInterceptor implements MethodInterceptor {
     private static final Tags NO_TAGS = Tags.empty();

--- a/telegram-bot-observability/src/test/java/io/ksilisk/telegrambot/observability/bpp/DeliveryThreadPoolExecutorFactoryObservabilityBeanPostProcessorTest.java
+++ b/telegram-bot-observability/src/test/java/io/ksilisk/telegrambot/observability/bpp/DeliveryThreadPoolExecutorFactoryObservabilityBeanPostProcessorTest.java
@@ -30,7 +30,7 @@ class DeliveryThreadPoolExecutorFactoryObservabilityBeanPostProcessorTest {
                     DeliveryThreadPoolExecutorFactory factory = ctx.getBean(DeliveryThreadPoolExecutorFactory.class);
                     SimpleMeterRegistry registry = ctx.getBean(SimpleMeterRegistry.class);
 
-                    ThreadPoolExecutor executor = factory.buildThreadPoolExecutor();
+                    ThreadPoolExecutor executor = (ThreadPoolExecutor) factory.buildThreadPoolExecutor();
 
                     // Gauges should be registered
                     Gauge active = registry.find(TelegramBotMetric.DELIVERY_POOL_ACTIVE.metricName())
@@ -87,7 +87,7 @@ class DeliveryThreadPoolExecutorFactoryObservabilityBeanPostProcessorTest {
                     DeliveryThreadPoolExecutorFactory factory = ctx.getBean(DeliveryThreadPoolExecutorFactory.class);
                     SimpleMeterRegistry registry = ctx.getBean(SimpleMeterRegistry.class);
 
-                    ThreadPoolExecutor executor = factory.buildThreadPoolExecutor();
+                    ThreadPoolExecutor executor = (ThreadPoolExecutor) factory.buildThreadPoolExecutor();
                     executor.shutdownNow();
 
                     assertNull(registry.find(TelegramBotMetric.DELIVERY_POOL_ACTIVE.metricName()).tags(Tags.empty()).gauge());
@@ -104,7 +104,7 @@ class DeliveryThreadPoolExecutorFactoryObservabilityBeanPostProcessorTest {
                     DeliveryThreadPoolExecutorFactory factory = ctx.getBean(DeliveryThreadPoolExecutorFactory.class);
                     SimpleMeterRegistry registry = ctx.getBean(SimpleMeterRegistry.class);
 
-                    ThreadPoolExecutor executor = factory.buildThreadPoolExecutor();
+                    ThreadPoolExecutor executor = (ThreadPoolExecutor) factory.buildThreadPoolExecutor();
                     executor.shutdownNow();
 
                     assertNull(registry.find(TelegramBotMetric.DELIVERY_POOL_ACTIVE.metricName()).tags(Tags.empty()).gauge());


### PR DESCRIPTION
## Summary

- Allow `DeliveryThreadPoolExecutorFactory` to return any `Executor` implementation.
- Use `Executor.execute(...)` for update delivery.
- Avoid shutting down executors managed by the application container.
- Document integration with Spring `ThreadPoolTaskExecutor` and `TaskDecorator`.
- Keep observability instrumentation for `ThreadPoolExecutor` and leave other executor types unchanged.
- Add coverage for non-`ExecutorService` executors.

This allows Spring applications to provide a managed `ThreadPoolTaskExecutor` for update delivery while retaining the existing default thread-pool lifecycle.

Fixes #97

## Validation

- `mvn clean verify -Dmaven.compiler.source=17 -Dmaven.compiler.target=17`
- `git diff --check`
- JUnit Platform manual execution of `DefaultUpdateDeliveryTest`: 9 tests successful

The repository currently uses Surefire 2.12.4, which reports zero JUnit 5 tests during the normal Maven test phase; the core test class was therefore executed directly with the JUnit Platform Console Launcher.

## Compatibility note

The factory return type is broadened from `ThreadPoolExecutor` to `Executor`. Existing source implementations that return `ThreadPoolExecutor` remain compatible, while binary consumers will need to rebuild.